### PR TITLE
Add Shadow DOM support

### DIFF
--- a/stylesheets/base.less
+++ b/stylesheets/base.less
@@ -2,7 +2,7 @@
 //  Base
 // ---------------------------------------------------------------------------
 
-    .editor {
+    .editor, :host {
         background: @color-charcoal;
         color: @color-white_dark;
         line-height: 1.5em;


### PR DESCRIPTION
Starting with v0.166 the Shadow DOM is enabled by default. According to [this document](https://atom.io/docs/latest/upgrading/upgrading-your-syntax-theme), all we need to do is add `:host` selector for every `.editor` and `.editor-colors`.