### PR TITLE
Replaced class-name with tag-name. Fix Background-Noise. Added support for .haml and .sass files.

### DIFF
--- a/index.less
+++ b/index.less
@@ -16,3 +16,4 @@
         @import "./stylesheets/Languages/less";
         @import "./stylesheets/Languages/markdown";
         @import "./stylesheets/Languages/yaml";
+        @import "./stylesheets/Languages/haml";

--- a/stylesheets/Languages/haml.less
+++ b/stylesheets/Languages/haml.less
@@ -1,0 +1,11 @@
+// ---------------------------------------------------------------------------
+//  Languages: HAML
+// ---------------------------------------------------------------------------
+
+    .text.haml {
+      .entity {
+        &.tag { color: @color-orange; }
+        &.class, &.id { color: @color-blue; }
+        &.pseudo-class, &.pseudo-element { color: @color-brown; }
+      }
+    }

--- a/stylesheets/Languages/sass.less
+++ b/stylesheets/Languages/sass.less
@@ -1,8 +1,9 @@
 // ---------------------------------------------------------------------------
-//  Languages: Sass
+//  Languages: Sass (Ruby Sass)
 // ---------------------------------------------------------------------------
 
-    .source.scss {
+    .source.scss,
+    .source.sass {
         .entity {
             // Sass: %placeholder
             &.placeholder { color: @color-blue_pale; }
@@ -13,4 +14,12 @@
 
         // Sass: $something
         .variable:not(.interpolation):not(.set) { color: @color-red_pale; }
+    }
+
+
+    //  .sass Files
+    // import styles from css
+
+    .source.sass {
+      .source.css;
     }

--- a/stylesheets/base.less
+++ b/stylesheets/base.less
@@ -2,7 +2,7 @@
 //  Base
 // ---------------------------------------------------------------------------
 
-    .editor, :host {
+    atom-text-editor, :host {
         background: @color-charcoal;
         color: @color-white_dark;
         line-height: 1.5em;

--- a/stylesheets/base.less
+++ b/stylesheets/base.less
@@ -8,7 +8,7 @@
         line-height: 1.5em;
 
         .selection .region { background: rgba(255, 255, 255, @opacity-highlight); }
-        .scroll-view .underlayer { background: @image-noise; }
+        .underlayer { background: @image-noise; }
         .wrap-guide { background: @color-charcoal_light; }
 
     // -------------------------------------


### PR DESCRIPTION
## Use the `atom-text-editor` tag instead of the `editor` class

https://discuss.atom.io/t/use-the-atom-text-editor-tag-instead-of-the-editor-class/14286

## Support for .haml files:

![haml](https://cloud.githubusercontent.com/assets/4481570/6037458/12bcc12e-ac54-11e4-9ccd-5910f918c669.jpg)

## Support for .sass files:

![sass](https://cloud.githubusercontent.com/assets/4481570/6037459/12d32fb8-ac54-11e4-8988-47207fec488b.jpg)