### PR TITLE
added string highlighting for golang

### DIFF
--- a/styles/Languages/go.less
+++ b/styles/Languages/go.less
@@ -38,4 +38,10 @@
         .placeholder {
             color: @color-yellow;
         }
+
+        .string.quoted.double{
+            .entity.name.import {
+                color: @color-green;
+            }
+        }
     }

--- a/styles/Languages/go.less
+++ b/styles/Languages/go.less
@@ -39,7 +39,7 @@
             color: @color-yellow;
         }
 
-        .string.quoted.double{
+        .string.quoted.double {
             .entity.name.import {
                 color: @color-green;
             }


### PR DESCRIPTION
I updated Atom to `1.12.2`. I noticed that strings in golang were not highlighted correctly anymore. This is how it looks now. 

<img width="581" alt="screen shot 2016-11-12 at 23 24 59" src="https://cloud.githubusercontent.com/assets/552769/20242465/53ca5fd0-a92f-11e6-8b01-15a606d51aa6.png">

This is how it should look like, which this PR in fact fixes. 

<img width="559" alt="screen shot 2016-11-12 at 23 24 09" src="https://cloud.githubusercontent.com/assets/552769/20242473/8184cdb6-a92f-11e6-8f13-496632444b57.png">

I feel like the fix of this PR is a hack and no proper solution. I did not dig deeper into how selectors changed in recent Atom upgrades. Therefore my limited understanding of the problem. Does somebody have more information? Should we simply merge this as it is? Here is also a screenshot of the DOM of the shown example above. 

<img width="1440" alt="screen shot 2016-11-12 at 23 28 52" src="https://cloud.githubusercontent.com/assets/552769/20242489/dda702c6-a92f-11e6-9f0f-d81ac323b46e.png">
